### PR TITLE
Remove rollout groups and targets for deleted rollouts

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutGroupManagement.java
@@ -8,6 +8,7 @@
  */
 package org.eclipse.hawkbit.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.validation.constraints.NotNull;
@@ -191,4 +192,7 @@ public interface RolloutGroupManagement {
      */
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
     long countTargetsOfRolloutsGroup(long rolloutGroupId);
+
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_DELETE_ROLLOUT_GROUP)
+    void deleteByIds(List<Long> ids);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -438,4 +438,6 @@ public interface RolloutManagement {
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_DELETE)
     void delete(long rolloutId);
 
+    @PreAuthorize(SpringEvalExpressions.IS_SYSTEM_CODE)
+    int deleteRolloutsDeletedInUI();
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -252,6 +252,9 @@ public interface RolloutManagement {
     Slice<Rollout> findByFiltersWithDetailedStatus(@NotNull Pageable pageable, @NotEmpty String searchText,
             boolean deleted);
 
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
+    Page<Rollout> findByDeletedIsTrue(@NotNull Pageable pageable);
+
     /**
      * Retrieves a specific rollout by its ID.
      *
@@ -439,5 +442,5 @@ public interface RolloutManagement {
     void delete(long rolloutId);
 
     @PreAuthorize(SpringEvalExpressions.IS_SYSTEM_CODE)
-    int deleteRolloutsDeletedInUI();
+    int deleteRolloutGroupsForRolloutsDeletedInUI();
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
@@ -148,6 +148,11 @@ public class TenantConfigurationProperties {
         public static final String ACTION_CLEANUP_ACTION_STATUS = "action.cleanup.actionStatus";
 
         /**
+         * Switch to enable/disable automatic action cleanup.
+         */
+        public static final String ROLLOUT_CLEANUP_ENABLED = "rollout.cleanup.enabled";
+
+        /**
          * Switch to enable/disable the multi-assignment feature.
          */
         public static final String MULTI_ASSIGNMENTS_ENABLED = "multi.assignments.enabled";

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutGroupManagement.java
@@ -298,4 +298,9 @@ public class JpaRolloutGroupManagement implements RolloutGroupManagement {
         return rolloutGroupRepository.countByRolloutId(rolloutId);
     }
 
+    @Override
+    public void deleteByIds(final List<Long> rolloutIds) {
+        rolloutGroupRepository.deleteByIds(rolloutIds);
+    }
+
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -209,6 +209,11 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     @Override
+    public Page<Rollout> findByDeletedIsTrue(final Pageable pageable) {
+        return rolloutRepository.findByDeletedIsTrue(pageable);
+    }
+
+    @Override
     public Optional<Rollout> get(final long rolloutId) {
         return rolloutRepository.findById(rolloutId).map(r -> (Rollout) r);
     }
@@ -1165,7 +1170,7 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
 
     @Override
     @Transactional(readOnly = false)
-    public int deleteRolloutsDeletedInUI() {
+    public int deleteRolloutGroupsForRolloutsDeletedInUI() {
         final Query deleteQuery = entityManager.createNativeQuery(QUERY_DELETE_ROLLOUTS_MARKED_AS_DELETED_IN_UI);
 
         LOGGER.warn("Rollout cleanup: Executing the following (native) query: {}", deleteQuery);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -58,6 +58,8 @@ import org.eclipse.hawkbit.repository.jpa.autoassign.AutoAssignScheduler;
 import org.eclipse.hawkbit.repository.jpa.autocleanup.AutoActionCleanup;
 import org.eclipse.hawkbit.repository.jpa.autocleanup.AutoCleanupScheduler;
 import org.eclipse.hawkbit.repository.jpa.autocleanup.CleanupTask;
+import org.eclipse.hawkbit.repository.jpa.autorolloutcleanup.AutoRolloutCleanup;
+import org.eclipse.hawkbit.repository.jpa.autorolloutcleanup.AutoRolloutCleanupScheduler;
 import org.eclipse.hawkbit.repository.jpa.builder.JpaDistributionSetBuilder;
 import org.eclipse.hawkbit.repository.jpa.builder.JpaDistributionSetTypeBuilder;
 import org.eclipse.hawkbit.repository.jpa.builder.JpaRolloutBuilder;
@@ -813,6 +815,25 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
     }
 
     /**
+     * {@link AutoRolloutCleanup} bean.
+     *
+     * @param deploymentManagement
+     *            Deployment management service
+     * @param configManagement
+     *            Tenant configuration service
+     * @param rolloutManagement
+     *            Rollout management service
+     *
+     * @return a new {@link AutoActionCleanup} bean
+     */
+    @Bean
+    CleanupTask rolloutCleanup(final DeploymentManagement deploymentManagement,
+                               final TenantConfigurationManagement configManagement,
+                               final RolloutManagement rolloutManagement) {
+        return new AutoRolloutCleanup(deploymentManagement, configManagement, rolloutManagement);
+    }
+
+    /**
      * {@link AutoCleanupScheduler} bean.
      * 
      * @param systemManagement
@@ -834,6 +855,30 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
             final SystemSecurityContext systemSecurityContext, final LockRegistry lockRegistry,
             final List<CleanupTask> cleanupTasks) {
         return new AutoCleanupScheduler(systemManagement, systemSecurityContext, lockRegistry, cleanupTasks);
+    }
+
+    /**
+     * {@link AutoRolloutCleanupScheduler} bean.
+     *
+     * @param systemManagement
+     *            to find all tenants
+     * @param systemSecurityContext
+     *            to run as system
+     * @param lockRegistry
+     *            to lock the tenant for auto assignment
+     * @param cleanupTasks
+     *            a list of cleanup tasks
+     *
+     * @return a new {@link AutoCleanupScheduler} bean
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    @Profile("!test")
+    @ConditionalOnProperty(prefix = "hawkbit.autorolloutcleanup.scheduler", name = "enabled", matchIfMissing = true)
+    AutoRolloutCleanupScheduler autoRolloutCleanupScheduler(final SystemManagement systemManagement,
+                                                     final SystemSecurityContext systemSecurityContext, final LockRegistry lockRegistry,
+                                                     final List<CleanupTask> cleanupTasks) {
+        return new AutoRolloutCleanupScheduler(systemManagement, systemSecurityContext, lockRegistry, cleanupTasks);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -829,8 +829,9 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
     @Bean
     CleanupTask rolloutCleanup(final DeploymentManagement deploymentManagement,
                                final TenantConfigurationManagement configManagement,
-                               final RolloutManagement rolloutManagement) {
-        return new AutoRolloutCleanup(deploymentManagement, configManagement, rolloutManagement);
+                               final RolloutManagement rolloutManagement,
+                               final RolloutGroupManagement rolloutGroupManagement) {
+        return new AutoRolloutCleanup(deploymentManagement, configManagement, rolloutManagement, rolloutGroupManagement);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
@@ -18,6 +18,8 @@ import org.eclipse.hawkbit.repository.jpa.model.JpaRollout;
 import org.eclipse.hawkbit.repository.model.Rollout;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
 import org.eclipse.hawkbit.repository.model.TenantAwareBaseEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -50,6 +52,8 @@ public interface RolloutRepository
      * @return {@link Rollout} for specific name
      */
     Optional<Rollout> findByName(String name);
+
+    Page<Rollout> findByDeletedIsTrue(Pageable pageRef);
 
     /**
      * Deletes all {@link TenantAwareBaseEntity} of a given tenant. For safety

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanup.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanup.java
@@ -1,0 +1,72 @@
+package org.eclipse.hawkbit.repository.jpa.autorolloutcleanup;
+
+import static org.eclipse.hawkbit.tenancy.configuration.TenantConfigurationProperties.TenantConfigurationKey.ROLLOUT_CLEANUP_ENABLED;
+
+import org.eclipse.hawkbit.repository.DeploymentManagement;
+import org.eclipse.hawkbit.repository.OffsetBasedPageRequest;
+import org.eclipse.hawkbit.repository.RolloutManagement;
+import org.eclipse.hawkbit.repository.TenantConfigurationManagement;
+import org.eclipse.hawkbit.repository.jpa.autocleanup.CleanupTask;
+import org.eclipse.hawkbit.repository.model.Rollout;
+import org.eclipse.hawkbit.repository.model.TenantConfigurationValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class AutoRolloutCleanup implements CleanupTask {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AutoRolloutCleanup.class);
+
+    private static final String ID = "rollout-cleanup";
+    private static final boolean ROLLOUT_CLEANUP_ENABLED_DEFAULT = true;
+
+    private final DeploymentManagement deploymentMgmt;
+    private final TenantConfigurationManagement configMgmt;
+    private final RolloutManagement rolloutMgmt;
+
+    public AutoRolloutCleanup(final DeploymentManagement deploymentMgmt, final TenantConfigurationManagement configMgmt, final RolloutManagement rolloutMgmt) {
+        this.deploymentMgmt = deploymentMgmt;
+        this.configMgmt = configMgmt;
+        this.rolloutMgmt = rolloutMgmt;
+    }
+
+    @Override
+    public void run() {
+        if (!isEnabled()) {
+            LOGGER.debug("Rollout cleanup is disabled for this tenant...");
+            return;
+        }
+
+        if(getRolloutDeletionStatus()){
+            final int rolloutCount = rolloutMgmt.deleteRolloutsDeletedInUI();
+            LOGGER.debug("Deleted {} rollouts which have been marked to be deleted in UI", rolloutCount);
+        }
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    private boolean getRolloutDeletionStatus() {
+        final Page<Rollout> rolloutPage = rolloutMgmt
+                .findAllWithDetailedStatus(new OffsetBasedPageRequest(0, 100, Sort.unsorted()), true);
+        final List<Rollout> rolloutList = rolloutPage.getContent();
+
+        return rolloutList.stream().anyMatch(Rollout::isDeleted);
+    }
+
+    private boolean isEnabled() {
+        final TenantConfigurationValue<Boolean> isEnabled = getConfigValue(ROLLOUT_CLEANUP_ENABLED, Boolean.class);
+        return isEnabled != null ? isEnabled.getValue() : ROLLOUT_CLEANUP_ENABLED_DEFAULT;
+    }
+
+    private <T extends Serializable> TenantConfigurationValue<T> getConfigValue(final String key,
+                                                                                final Class<T> valueType) {
+        return configMgmt.getConfigurationValue(key, valueType);
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupScheduler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupScheduler.java
@@ -1,0 +1,68 @@
+package org.eclipse.hawkbit.repository.jpa.autorolloutcleanup;
+
+import org.eclipse.hawkbit.repository.SystemManagement;
+import org.eclipse.hawkbit.repository.jpa.autocleanup.CleanupTask;
+import org.eclipse.hawkbit.security.SystemSecurityContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.integration.support.locks.LockRegistry;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+
+public class AutoRolloutCleanupScheduler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AutoRolloutCleanupScheduler.class);
+
+    private static final String AUTO_ROLLOUT_CLEANUP = "auto-rollout-cleanup";
+    private static final String SEP = ".";
+    private static final String PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL = "${hawkbit.autorolloutcleanup.scheduler.fixedDelay:2592000000}"; // 30 days
+
+    private final SystemManagement systemManagement;
+    private final SystemSecurityContext systemSecurityContext;
+    private final LockRegistry lockRegistry;
+    private final List<CleanupTask> cleanupTasks;
+
+    public AutoRolloutCleanupScheduler(final SystemManagement systemManagement, final SystemSecurityContext systemSecurityContext,
+                                       final LockRegistry lockRegistry, final List<CleanupTask> cleanupTasks) {
+        this.systemManagement = systemManagement;
+        this.systemSecurityContext = systemSecurityContext;
+        this.lockRegistry = lockRegistry;
+        this.cleanupTasks = cleanupTasks;
+    }
+
+    @Scheduled(initialDelayString = PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL, fixedDelayString = PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL)
+    public void run() {
+        LOGGER.debug("Auto rollout cleanup scheduler has been triggered.");
+
+        if(!cleanupTasks.isEmpty()) {
+            systemSecurityContext.runAsSystem(this::executeAutoRolloutCleanup);
+        }
+    }
+
+    private Void executeAutoRolloutCleanup() {
+        systemManagement.forEachTenant(tenant -> cleanupTasks.forEach(task -> {
+            final Lock lock = obtainLock(task, tenant);
+
+            if (!lock.tryLock()) {
+                return;
+            }
+
+            LOGGER.debug("Obtained lock with key: {}", AUTO_ROLLOUT_CLEANUP + SEP + task.getId() + SEP + tenant);
+
+            try {
+                task.run();
+            } catch (final RuntimeException e) {
+                LOGGER.error("Rollout cleanup task failed.", e);
+            } finally {
+                lock.unlock();
+                LOGGER.debug("Unlocked lock with key: {}", AUTO_ROLLOUT_CLEANUP + SEP + task.getId() + SEP + tenant);
+            }
+        }));
+        return null;
+    }
+
+    private Lock obtainLock(final CleanupTask task, final String tenant) {
+        return lockRegistry.obtain(AUTO_ROLLOUT_CLEANUP + SEP + task.getId() + SEP + tenant);
+    }
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupScheduler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupScheduler.java
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) 2022 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.hawkbit.repository.jpa.autorolloutcleanup;
 
 import org.eclipse.hawkbit.repository.SystemManagement;
@@ -16,7 +24,7 @@ public class AutoRolloutCleanupScheduler {
 
     private static final String AUTO_ROLLOUT_CLEANUP = "auto-rollout-cleanup";
     private static final String SEP = ".";
-    private static final String PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL = "${hawkbit.autorolloutcleanup.scheduler.fixedDelay:2592000000}"; // 30 days
+    private static final String PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL = "${hawkbit.autorolloutcleanup.scheduler.interval:2592000000}"; // 30 days
 
     private final SystemManagement systemManagement;
     private final SystemSecurityContext systemSecurityContext;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_18__remove_constraint_action_rolloutgroup___DB2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_18__remove_constraint_action_rolloutgroup___DB2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_action
+DROP CONSTRAINT fk_action_rolloutgroup;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_18__remove_constraint_action_rolloutgroup___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_18__remove_constraint_action_rolloutgroup___H2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_action
+DROP CONSTRAINT fk_action_rolloutgroup;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_18__remove_constraint_action_rolloutgroup___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_18__remove_constraint_action_rolloutgroup___MYSQL.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_action
+DROP CONSTRAINT fk_action_rolloutgroup;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_18__remove_constraint_action_rolloutgroup___POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_18__remove_constraint_action_rolloutgroup___POSTGRESQL.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_action
+DROP CONSTRAINT fk_action_rolloutgroup;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_18__remove_constraint_action_rolloutgroup___SQL_SERVER.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_18__remove_constraint_action_rolloutgroup___SQL_SERVER.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_action
+DROP CONSTRAINT fk_action_rolloutgroup;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupSchedulerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupSchedulerTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2022 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa.autorolloutcleanup;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;
+import org.eclipse.hawkbit.repository.jpa.autocleanup.AutoCleanupScheduler;
+import org.eclipse.hawkbit.repository.jpa.autocleanup.CleanupTask;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.support.locks.LockRegistry;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Feature("Component Tests - Repository")
+@Story("Auto rollout cleanup scheduler")
+public class AutoRolloutCleanupSchedulerTest extends AbstractJpaIntegrationTest {
+
+    private final AtomicInteger counter = new AtomicInteger();
+
+    @Autowired
+    private LockRegistry lockRegistry;
+
+    @Before
+    public void setUp() {
+        counter.set(0);
+    }
+
+    @Test
+    @Description("Verifies that all cleanup handlers are executed regardless if one of them throws an error")
+    public void executeHandlerChain() {
+
+        new AutoCleanupScheduler(systemManagement, systemSecurityContext, lockRegistry, Arrays.asList(
+                new org.eclipse.hawkbit.repository.jpa.autorolloutcleanup.AutoRolloutCleanupSchedulerTest.SuccessfulCleanup(), new org.eclipse.hawkbit.repository.jpa.autorolloutcleanup.AutoRolloutCleanupSchedulerTest.SuccessfulCleanup(), new org.eclipse.hawkbit.repository.jpa.autorolloutcleanup.AutoRolloutCleanupSchedulerTest.FailingCleanup(), new org.eclipse.hawkbit.repository.jpa.autorolloutcleanup.AutoRolloutCleanupSchedulerTest.SuccessfulCleanup())).run();
+
+        assertThat(counter.get()).isEqualTo(4);
+
+    }
+
+    private class SuccessfulCleanup implements CleanupTask {
+
+        @Override
+        public void run() {
+            counter.incrementAndGet();
+        }
+
+        @Override
+        public String getId() {
+            return "success";
+        }
+
+    }
+
+    private class FailingCleanup implements CleanupTask {
+
+        @Override
+        public void run() {
+            counter.incrementAndGet();
+            throw new RuntimeException("cleanup failed");
+        }
+
+        @Override
+        public String getId() {
+            return "success";
+        }
+
+    }
+
+}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2022 devolo AG and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.hawkbit.repository.jpa.autorolloutcleanup;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;
+import org.eclipse.hawkbit.repository.jpa.autocleanup.AutoActionCleanup;
+import org.eclipse.hawkbit.repository.jpa.model.JpaRollout;
+import org.eclipse.hawkbit.repository.model.*;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class for {@link AutoActionCleanup}.
+ *
+ */
+@Feature("Component Tests - Repository")
+@Story("Rollout cleanup handler")
+public class AutoRolloutCleanupTest extends AbstractJpaIntegrationTest {
+
+    @Autowired
+    private AutoRolloutCleanup autoRolloutCleanup;
+
+    @Test
+    @Description("Verifies that rollout groups for rollouts that are not deleted in UI are not cleaned up.")
+    public void rolloutGroupsForRolloutsNotDeletedAreNotCleanedUp() {
+        testdataFactory.createTargets(20, "test");
+        testdataFactory.createTargets(20, "controller");
+
+        final DistributionSet ds = distributionSetManagement.create(entityFactory.distributionSet().create().name("test-ds").version("1").type("os"));
+
+        final Rollout rollout1 = rolloutManagement.create(entityFactory.rollout().create().name("exampleRollout").targetFilterQuery("name==test*").set(ds), 10, new RolloutGroupConditionBuilder().withDefaults()
+                .successCondition(RolloutGroup.RolloutGroupSuccessCondition.THRESHOLD, "10").build());
+
+        final Rollout rollout2 = rolloutManagement.create(entityFactory.rollout().create().name("exampleRollout2").targetFilterQuery("name==controller*").set(ds), 15, new RolloutGroupConditionBuilder().withDefaults()
+                .successCondition(RolloutGroup.RolloutGroupSuccessCondition.THRESHOLD, "10").build());
+
+        assertThat(rolloutRepository.count()).isEqualTo(2);
+        assertThat(rolloutGroupRepository.count()).isEqualTo(25);
+
+        // Mark rollout 1 as deleted
+        final JpaRollout rolloutToDelete = rolloutRepository.findById(rollout1.getId()).get();
+        assertThat(rolloutToDelete.isDeleted()).isEqualTo(false);
+        rolloutToDelete.setDeleted(true);
+        assertThat(rolloutToDelete.isDeleted()).isEqualTo(true);
+
+        assertThat(rolloutRepository.count()).isEqualTo(2);
+        rolloutRepository.save(rolloutToDelete);
+
+        // Run cleanup
+        autoRolloutCleanup.run();
+
+        // Check that rollout groups are deleted
+        assertThat(rolloutRepository.count()).isEqualTo(2);
+        assertThat(rolloutGroupManagement.countByRollout(rollout1.getId())).isEqualTo(0);
+        assertThat(rolloutGroupManagement.countByRollout(rollout2.getId())).isEqualTo(15);
+    }
+}

--- a/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
+++ b/hawkbit-security-core/src/main/java/org/eclipse/hawkbit/im/authentication/SpPermission.java
@@ -429,6 +429,9 @@ public final class SpPermission {
          */
         public static final String HAS_AUTH_TENANT_CONFIGURATION = HAS_AUTH_PREFIX + TENANT_CONFIGURATION
                 + HAS_AUTH_SUFFIX + HAS_AUTH_OR + IS_SYSTEM_CODE;
+        private static final String DELETE_ROLLOUT_GROUP = "DELETE_ROLLOUT_GROUP";
+        public static final String HAS_AUTH_DELETE_ROLLOUT_GROUP = HAS_AUTH_PREFIX + DELETE_ROLLOUT_GROUP
+                + HAS_AUTH_SUFFIX + HAS_AUTH_OR + IS_SYSTEM_CODE;
 
         private SpringEvalExpressions() {
             // utility class


### PR DESCRIPTION
When rollouts are marked as deleted in UI they remain in the database. To speed up rollout creation, we now:
- Remove entries in `sp_rolloutgroup` for rollouts that are marked as deleted
- Cascade delete entries in `sp_rollouttargetgroup` for rollout groups that are deleted

This rollout cleanup runs every 30 days and can delete entries corresponding to up to a 100 rollouts marked as deleted.