### PR TITLE
Fix flyway migration error

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_18__remove_constraint_action_rolloutgroup___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_18__remove_constraint_action_rolloutgroup___MYSQL.sql
@@ -1,2 +1,2 @@
 ALTER TABLE sp_action
-DROP CONSTRAINT fk_action_rolloutgroup;
+DROP FOREIGN KEY fk_action_rolloutgroup;

--- a/hawkbit-runtime/hawkbit-update-server/pom.xml
+++ b/hawkbit-runtime/hawkbit-update-server/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
          <groupId>org.eclipse.hawkbit</groupId>
          <artifactId>hawkbit-extension-artifact-repository-s3</artifactId>
-         <version>${project.version}</version>
+         <version>0.3.0M7</version>
    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
- Change s3 artifact version
- Fix error in FlyWayDB migration script: Use `DROP FOREIGN KEY` instead of `DROP CONSTRAINT`