### PR TITLE
Fix rollout cleanup

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -10,6 +10,7 @@ package org.eclipse.hawkbit.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
@@ -26,14 +27,9 @@ import org.eclipse.hawkbit.repository.exception.AssignmentQuotaExceededException
 import org.eclipse.hawkbit.repository.exception.RSQLParameterSyntaxException;
 import org.eclipse.hawkbit.repository.exception.RSQLParameterUnsupportedFieldException;
 import org.eclipse.hawkbit.repository.exception.RolloutIllegalStateException;
-import org.eclipse.hawkbit.repository.model.DistributionSet;
-import org.eclipse.hawkbit.repository.model.Rollout;
+import org.eclipse.hawkbit.repository.model.*;
 import org.eclipse.hawkbit.repository.model.Rollout.RolloutStatus;
-import org.eclipse.hawkbit.repository.model.RolloutGroup;
 import org.eclipse.hawkbit.repository.model.RolloutGroup.RolloutGroupStatus;
-import org.eclipse.hawkbit.repository.model.RolloutGroupConditions;
-import org.eclipse.hawkbit.repository.model.RolloutGroupsValidation;
-import org.eclipse.hawkbit.repository.model.Target;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -255,6 +251,9 @@ public interface RolloutManagement {
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
     Page<Rollout> findByDeletedIsTrue(@NotNull Pageable pageable);
 
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
+    Page<Rollout> findByIsCleanedUpIsFalse(@NotNull Pageable pageable);
+
     /**
      * Retrieves a specific rollout by its ID.
      *
@@ -442,5 +441,5 @@ public interface RolloutManagement {
     void delete(long rolloutId);
 
     @PreAuthorize(SpringEvalExpressions.IS_SYSTEM_CODE)
-    int deleteRolloutGroupsForRolloutsDeletedInUI();
+    void setRolloutAsCleanedUp(@NotNull final Rollout rollout);
 }

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -10,7 +10,6 @@ package org.eclipse.hawkbit.repository;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.validation.ConstraintViolationException;
 import javax.validation.Valid;
@@ -85,7 +84,7 @@ public interface RolloutManagement {
     long countByIsCleanUp();
 
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
-    long countAllRolloutsInRepository();
+    long countRolloutsMarkedAsDeleted();
 
     /**
      * Count rollouts by given text in name or description.
@@ -258,7 +257,7 @@ public interface RolloutManagement {
     Page<Rollout> findByDeletedIsTrue(@NotNull Pageable pageable);
 
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
-    Page<Rollout> findByIsCleanedUpIsFalse(@NotNull Pageable pageable);
+    Page<Rollout> findByIsCleanedUpIsFalseAndDeletedIsTrue(@NotNull Pageable pageable);
 
     /**
      * Retrieves a specific rollout by its ID.

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/RolloutManagement.java
@@ -81,6 +81,12 @@ public interface RolloutManagement {
     @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
     long count();
 
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
+    long countByIsCleanUp();
+
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_ROLLOUT_MANAGEMENT_READ)
+    long countAllRolloutsInRepository();
+
     /**
      * Count rollouts by given text in name or description.
      *

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Rollout.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Rollout.java
@@ -42,6 +42,8 @@ public interface Rollout extends NamedEntity {
      */
     boolean isDeleted();
 
+    boolean getIsCleanedUp();
+
     /**
      * @return {@link DistributionSet} that is rolled out
      */

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -1012,8 +1012,8 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
         return rolloutRepository.count(RolloutSpecification.isCleanedUp(true));
     }
 
-    public long countAllRolloutsInRepository() {
-        return rolloutRepository.count();
+    public long countRolloutsMarkedAsDeleted() {
+        return rolloutRepository.count(RolloutSpecification.deleted(true));
     }
 
     @Override
@@ -1030,8 +1030,8 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
         return JpaRolloutHelper.convertPage(findAll, pageable);
     }
 
-    public Page<Rollout> findByIsCleanedUpIsFalse(final Pageable pageReq) {
-        return rolloutRepository.findByIsCleanedUpIsFalse(pageReq);
+    public Page<Rollout> findByIsCleanedUpIsFalseAndDeletedIsTrue(final Pageable pageReq) {
+        return rolloutRepository.findByIsCleanedUpIsFalseAndDeletedIsTrue(pageReq);
     }
 
     @Override

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -1008,6 +1008,15 @@ public class JpaRolloutManagement extends AbstractRolloutManagement {
     }
 
     @Override
+    public long countByIsCleanUp() {
+        return rolloutRepository.count(RolloutSpecification.isCleanedUp(true));
+    }
+
+    public long countAllRolloutsInRepository() {
+        return rolloutRepository.count();
+    }
+
+    @Override
     public long countByFilters(final String searchText) {
         return rolloutRepository.count(JpaRolloutHelper.likeNameOrDescription(searchText, false));
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RepositoryApplicationConfiguration.java
@@ -827,11 +827,10 @@ public class RepositoryApplicationConfiguration extends JpaBaseConfiguration {
      * @return a new {@link AutoActionCleanup} bean
      */
     @Bean
-    CleanupTask rolloutCleanup(final DeploymentManagement deploymentManagement,
-                               final TenantConfigurationManagement configManagement,
-                               final RolloutManagement rolloutManagement,
-                               final RolloutGroupManagement rolloutGroupManagement) {
-        return new AutoRolloutCleanup(deploymentManagement, configManagement, rolloutManagement, rolloutGroupManagement);
+    CleanupTask rolloutCleanup(final RolloutManagement rolloutManagement,
+                               final RolloutGroupManagement rolloutGroupManagement,
+                               final QuotaManagement quotaManagement) {
+        return new AutoRolloutCleanup(rolloutManagement, rolloutGroupManagement, quotaManagement);
     }
 
     /**

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
@@ -61,7 +61,7 @@ public interface RolloutRepository
      * @param pageRef
      * @return
      */
-    Page<Rollout> findByIsCleanedUpIsFalse(Pageable pageRef);
+    Page<Rollout> findByIsCleanedUpIsFalseAndDeletedIsTrue(Pageable pageRef);
 
     /**
      * Deletes all {@link TenantAwareBaseEntity} of a given tenant. For safety

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/RolloutRepository.java
@@ -56,6 +56,14 @@ public interface RolloutRepository
     Page<Rollout> findByDeletedIsTrue(Pageable pageRef);
 
     /**
+     * Finds all rollouts that have `is_cleaned_up` set to false
+     *
+     * @param pageRef
+     * @return
+     */
+    Page<Rollout> findByIsCleanedUpIsFalse(Pageable pageRef);
+
+    /**
      * Deletes all {@link TenantAwareBaseEntity} of a given tenant. For safety
      * reasons (this is a "delete everything" query after all) we add the tenant
      * manually to query even if this will by done by {@link EntityManager}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanup.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanup.java
@@ -80,7 +80,7 @@ public class AutoRolloutCleanup implements CleanupTask {
     }
 
     private List<Rollout> getRolloutsNotYetCleanedUp() {
-        final Page<Rollout> rolloutPage = rolloutMgmt.findByIsCleanedUpIsFalse(new OffsetBasedPageRequest(0, rolloutsPerCleanup, Sort.unsorted()));
+        final Page<Rollout> rolloutPage = rolloutMgmt.findByIsCleanedUpIsFalseAndDeletedIsTrue(new OffsetBasedPageRequest(0, rolloutsPerCleanup, Sort.unsorted()));
         final List<Rollout> rolloutList = rolloutPage.getContent();
 
         return rolloutList;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupScheduler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupScheduler.java
@@ -25,6 +25,7 @@ public class AutoRolloutCleanupScheduler {
     private static final String AUTO_ROLLOUT_CLEANUP = "auto-rollout-cleanup";
     private static final String SEP = ".";
     private static final String PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL = "${hawkbit.autorolloutcleanup.scheduler.interval:2592000000}"; // 30 days
+    private static final String PROP_AUTH_ROLLOUT_CLEANUP_INITIAL_DELAY = "${hawkbit.autorolloutcleanup.scheduler.interval:60000}"; // 1 minute
 
     private final SystemManagement systemManagement;
     private final SystemSecurityContext systemSecurityContext;
@@ -39,7 +40,7 @@ public class AutoRolloutCleanupScheduler {
         this.cleanupTasks = cleanupTasks;
     }
 
-    @Scheduled(initialDelayString = PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL, fixedDelayString = PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL)
+    @Scheduled(initialDelayString = PROP_AUTH_ROLLOUT_CLEANUP_INITIAL_DELAY, fixedDelayString = PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL)
     public void run() {
         LOGGER.debug("Auto rollout cleanup scheduler has been triggered.");
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupScheduler.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupScheduler.java
@@ -25,7 +25,7 @@ public class AutoRolloutCleanupScheduler {
     private static final String AUTO_ROLLOUT_CLEANUP = "auto-rollout-cleanup";
     private static final String SEP = ".";
     private static final String PROP_AUTO_ROLLOUT_CLEANUP_INTERVAL = "${hawkbit.autorolloutcleanup.scheduler.interval:2592000000}"; // 30 days
-    private static final String PROP_AUTH_ROLLOUT_CLEANUP_INITIAL_DELAY = "${hawkbit.autorolloutcleanup.scheduler.interval:60000}"; // 1 minute
+    private static final String PROP_AUTH_ROLLOUT_CLEANUP_INITIAL_DELAY = "${hawkbit.autorolloutcleanup.scheduler.initialDelay:1000}"; // 1 second
 
     private final SystemManagement systemManagement;
     private final SystemSecurityContext systemSecurityContext;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
@@ -139,6 +139,9 @@ public class JpaRollout extends AbstractJpaNamedEntity implements Rollout, Event
     @Max(Action.WEIGHT_MAX)
     private Integer weight;
 
+    @Column(name = "is_cleaned_up", nullable = false)
+    private boolean isCleanedUp = false;
+
     @Transient
     private transient TotalTargetCountStatus totalTargetCountStatus;
 
@@ -220,6 +223,10 @@ public class JpaRollout extends AbstractJpaNamedEntity implements Rollout, Event
     public void setWeight(final Integer weight) {
         this.weight = weight;
     }
+
+    public boolean getIsCleanedUp() { return isCleanedUp; }
+
+    public void setIsCleanedUp(final boolean isCleanedUp) { this.isCleanedUp = isCleanedUp; }
 
     @Override
     public long getTotalTargets() {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/RolloutSpecification.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/RolloutSpecification.java
@@ -61,4 +61,21 @@ public final class RolloutSpecification {
             return predicate;
         };
     }
+
+    /**
+     * {@link Specification} for retrieving {@link Rollout}s by its DELETED
+     * attribute. Includes fetch for stuff that is required for {@link Rollout}
+     * queries.
+     *
+     * @param deleted
+     *            TRUE/FALSE are compared to the attribute DELETED. If NULL the
+     *            attribute is ignored
+     * @return the {@link Rollout} {@link Specification}
+     */
+    public static Specification<JpaRollout> deleted(final boolean deleted) {
+        return (root, query, cb) -> {
+            final Predicate predicate = cb.equal(root.<Boolean> get(JpaRollout_.deleted), deleted);
+            return predicate;
+        };
+    }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/RolloutSpecification.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/RolloutSpecification.java
@@ -45,4 +45,20 @@ public final class RolloutSpecification {
 
     }
 
+    /**
+     * {@link Specification} for retrieving {@link Rollout}s by its DELETED
+     * attribute. Includes fetch for stuff that is required for {@link Rollout}
+     * queries.
+     *
+     * @param isCleanedUp
+     *            TRUE/FALSE are compared to the attribute isCleanedUp. If NULL the
+     *            attribute is ignored
+     * @return the {@link Rollout} {@link Specification}
+     */
+    public static Specification<JpaRollout> isCleanedUp(final boolean isCleanedUp) {
+        return (root, query, cb) -> {
+            final Predicate predicate = cb.equal(root.<Boolean> get(JpaRollout_.isCleanedUp), isCleanedUp);
+            return predicate;
+        };
+    }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_19__add_column_cleanup___DB2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_19__add_column_cleanup___DB2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_cleaned_up TINYINT(1) DEFAULT '0' NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_19__add_column_cleanup___H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_19__add_column_cleanup___H2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_cleaned_up TINYINT(1) DEFAULT '0' NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_19__add_column_cleanup___MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_19__add_column_cleanup___MYSQL.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_cleaned_up TINYINT(1) DEFAULT '0' NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_19__add_column_cleanup___POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_19__add_column_cleanup___POSTGRESQL.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_cleaned_up TINYINT(1) DEFAULT '0' NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_19__add_column_cleanup___SQL_SERVER.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_19__add_column_cleanup___SQL_SERVER.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_cleaned_up TINYINT(1) DEFAULT '0' NOT NULL;

--- a/hawkbit-runtime/hawkbit-update-server/src/main/java/org/eclipse/hawkbit/app/CustomInfoContributor.java
+++ b/hawkbit-runtime/hawkbit-update-server/src/main/java/org/eclipse/hawkbit/app/CustomInfoContributor.java
@@ -37,8 +37,9 @@ public class CustomInfoContributor implements InfoContributor {
         final SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
         dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
 
-        Map<String, Object> targetsByState = new HashMap<String, Object>();
-        Map<String, Object> rolloutsByState = new HashMap<String, Object>();
+        Map<String, Object> targetsByState = new HashMap<>();
+        Map<String, Object> rolloutsByState = new HashMap<>();
+        Map<String, Object> rolloutCleanupState = new HashMap<>();
 
         // Setup timer to record elapsed time for fetching statistics
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
@@ -76,8 +77,12 @@ public class CustomInfoContributor implements InfoContributor {
             rolloutsByState.put("stopped", rolloutList.stream().filter(rollout -> Rollout.RolloutStatus.STOPPED.equals(rollout.getStatus())).count());
             rolloutsByState.put("waiting_for_approval", rolloutList.stream().filter(rollout -> Rollout.RolloutStatus.WAITING_FOR_APPROVAL.equals(rollout.getStatus())).count());
 
+            rolloutCleanupState.put("all", rolloutManagement.countAllRolloutsInRepository());
+            rolloutCleanupState.put("cleaned_up", rolloutManagement.countByIsCleanUp());
+
             builder.withDetail("targets_by_state", targetsByState);
             builder.withDetail("rollouts_by_state", rolloutsByState);
+            builder.withDetail("rollouts_by_cleanup_state", rolloutCleanupState);
             builder.withDetail("total_targets", targetManagement.count());
             builder.withDetail("offline_targets", targetManagement.countByFilters(null, Boolean.TRUE, null, null, Boolean.FALSE));
             builder.withDetail("total_distribution_sets", distributionSetManagement.count());

--- a/hawkbit-runtime/hawkbit-update-server/src/main/java/org/eclipse/hawkbit/app/CustomInfoContributor.java
+++ b/hawkbit-runtime/hawkbit-update-server/src/main/java/org/eclipse/hawkbit/app/CustomInfoContributor.java
@@ -77,7 +77,7 @@ public class CustomInfoContributor implements InfoContributor {
             rolloutsByState.put("stopped", rolloutList.stream().filter(rollout -> Rollout.RolloutStatus.STOPPED.equals(rollout.getStatus())).count());
             rolloutsByState.put("waiting_for_approval", rolloutList.stream().filter(rollout -> Rollout.RolloutStatus.WAITING_FOR_APPROVAL.equals(rollout.getStatus())).count());
 
-            rolloutCleanupState.put("all", rolloutManagement.countAllRolloutsInRepository());
+            rolloutCleanupState.put("deleted_in_ui", rolloutManagement.countRolloutsMarkedAsDeleted());
             rolloutCleanupState.put("cleaned_up", rolloutManagement.countByIsCleanUp());
 
             builder.withDetail("targets_by_state", targetsByState);


### PR DESCRIPTION
- Use @Value to allow `rolloutsPerCleanup` to be configured via `application.properties`
- Initial delay of rollout cleanup can now be configured as property
- Add Flyway migration scripts to include a new column `is_cleaned_up` to `sp_rollout` table
- Deleted rollout groups only for rollouts that are a) marked for deletion and b) has `is_cleaned_up` flag set to false
- Expose rollout cleanup status in `/info` endpoint