### PR TITLE
Increase width of text boxes in rollout creation UI

### DIFF
--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/RolloutWindowLayoutComponentBuilder.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/RolloutWindowLayoutComponentBuilder.java
@@ -94,7 +94,7 @@ public final class RolloutWindowLayoutComponentBuilder {
             final Component advancedGroupDefinitionTab) {
         final TabSheet groupsDefinitionTabs = new TabSheet();
         groupsDefinitionTabs.setId(UIComponentIdProvider.ROLLOUT_GROUPS);
-        groupsDefinitionTabs.setWidth(850, Unit.PIXELS);
+        groupsDefinitionTabs.setWidth(950, Unit.PIXELS);
         groupsDefinitionTabs.setHeight(300, Unit.PIXELS);
         groupsDefinitionTabs.setStyleName(SPUIStyleDefinitions.ROLLOUT_GROUPS);
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/components/RolloutFormLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/components/RolloutFormLayout.java
@@ -10,6 +10,8 @@ package org.eclipse.hawkbit.ui.rollout.window.components;
 
 import java.util.function.Consumer;
 
+import com.vaadin.server.Sizeable;
+import org.eclipse.hawkbit.repository.jpa.autorolloutcleanup.AutoRolloutCleanupScheduler;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.ui.common.builder.BoundComponent;
@@ -52,6 +54,8 @@ public class RolloutFormLayout extends ValidatableLayout {
 
     private static final int CAPTION_COLUMN = 0;
     private static final int FIELD_COLUMN = 1;
+
+    private static final float TEXT_BOX_WIDTH = 320.0F;
 
     private final VaadinMessageSource i18n;
 
@@ -115,6 +119,8 @@ public class RolloutFormLayout extends ValidatableLayout {
         final TextField textField = FormComponentBuilder
                 .createNameInput(binder, i18n, UIComponentIdProvider.ROLLOUT_NAME_FIELD_ID).getComponent();
         textField.setCaption(null);
+        textField.setWidth(TEXT_BOX_WIDTH, Sizeable.Unit.PIXELS);
+
         return textField;
     }
 
@@ -128,12 +134,17 @@ public class RolloutFormLayout extends ValidatableLayout {
                 distributionSetDataProvider, i18n, UIComponentIdProvider.ROLLOUT_DS_ID).getComponent();
         dsComboBox.setCaption(null);
 
+        dsComboBox.setWidth(TEXT_BOX_WIDTH, Sizeable.Unit.PIXELS);
+
         return dsComboBox;
     }
 
     private BoundComponent<ComboBox<ProxyTargetFilterQuery>> createTargetFilterQueryCombo() {
-        return FormComponentBuilder.createTargetFilterQueryCombo(binder, atLeastOneTargetPresentValidator(),
+        final BoundComponent<ComboBox<ProxyTargetFilterQuery>> targetFilterQueryComboBox = FormComponentBuilder.createTargetFilterQueryCombo(binder, atLeastOneTargetPresentValidator(),
                 targetFilterQueryDataProvider, i18n, UIComponentIdProvider.ROLLOUT_TARGET_FILTER_COMBO_ID);
+        targetFilterQueryComboBox.getComponent().setWidth(TEXT_BOX_WIDTH, Sizeable.Unit.PIXELS);
+
+        return targetFilterQueryComboBox;
 
     }
 
@@ -164,6 +175,7 @@ public class RolloutFormLayout extends ValidatableLayout {
         final TextArea description = FormComponentBuilder
                 .createDescriptionInput(binder, i18n, UIComponentIdProvider.ROLLOUT_DESCRIPTION_ID).getComponent();
         description.setCaption(null);
+        description.setWidth(TEXT_BOX_WIDTH, Sizeable.Unit.PIXELS);
 
         return description;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/layouts/AbstractRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/layouts/AbstractRolloutWindowLayout.java
@@ -54,7 +54,7 @@ public abstract class AbstractRolloutWindowLayout implements EntityWindowLayout<
         rootLayout.setColumns(4);
         rootLayout.setStyleName("marginTop");
         rootLayout.setColumnExpandRatio(3, 1);
-        rootLayout.setWidth(850, Unit.PIXELS);
+        rootLayout.setWidth(950, Unit.PIXELS);
 
         addComponents(rootLayout);
 


### PR DESCRIPTION
- Set width of text boxes for "Name", "Distribution set", "Custom Target Filter", and "Description" to 320 px. 
- Increase overall width of rollout creation dialog UI from 850 to 950 px.

<img src="https://github.com/devolo/hawkbit/files/9734271/Screenshot.2022-10-07.at.15.07.08.pdf" width="75%">
