### PR TITLE
Action status cleanup fix

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoactionstatuscleanup/AutoActionStatusCleanupTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoactionstatuscleanup/AutoActionStatusCleanupTest.java
@@ -83,7 +83,7 @@ public class AutoActionStatusCleanupTest extends AbstractJpaIntegrationTest {
 
         assertThat(target.getIsCleanedUp()).isEqualTo(true);
         assertThat(actionRepository.count()).isEqualTo(2);
-        assertThat(actionStatusRepository.count()).isEqualTo(2); // Remove status only for previous action
+        assertThat(actionStatusRepository.count()).isEqualTo(3); // Remove only the penultimate status only for previous action
     }
 
     @Test


### PR DESCRIPTION
- Ignore the latest action status from cleanup
- Ignore action statuses in status `ERROR` from cleanup
- Fix test for ActionStatusCleanup to facilitate the above changes