### PR TITLE
Fix a bug that prevented assignment for some users

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -855,6 +855,6 @@ public interface TargetManagement {
      *             in case the targets do not exist and cannot be
      *             updated
      */
-    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_REPOSITORY)
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_UPDATE_TARGET)
     void updateIsCleanedUpForTargetsWithIds(List<Long> targetIds, boolean isCleanedUp);
 }


### PR DESCRIPTION
Assigning a distribution set to a target in the hawkBit UI failed quietly for a lot of users. 

The cause of the bug is as follows: Assigning a distribution set to a target causes the target's `is_cleaned_up` property to be set to `false` (so that it is a candidate for auto action status cleanup). The function that does this requires a permission of `UPDATE_REPOSITORY`. However, users who have `UPDATE_TARGET` permission could already assign distribution set via the UI, which led to this code failing without any feedback. 

The permission has now been updated to `UPDATE_TARGET`, since the user is only updating the `sp_target` database.