### PR TITLE
Use composite query to fetch target count by update status

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/TargetManagement.java
@@ -102,6 +102,15 @@ public interface TargetManagement {
     long countByFilters(Collection<TargetUpdateStatus> status, Boolean overdueState, String searchText,
             Long installedOrAssignedDistributionSetId, Boolean selectTargetWithNoTag, String... tagNames);
 
+
+    /**
+     * Count {@link Target}s in each update status.
+     *
+     * @return an array of target counts per update status.
+     */
+    @PreAuthorize(SpringEvalExpressions.HAS_AUTH_READ_TARGET)
+    List<Long> countByUpdateStatus();
+
     /**
      * Counts number of targets with given with given distribution set Id
      *

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -463,6 +463,11 @@ public class JpaTargetManagement implements TargetManagement {
     }
 
     @Override
+    public List<Long> countByUpdateStatus() {
+        return targetRepository.countByUpdateStatus();
+    }
+
+    @Override
     public long countByIsCleanedUp() {
         return targetRepository.count(TargetSpecifications.isCleanedUp(true));
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetRepository.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import javax.persistence.EntityManager;
 
+import org.eclipse.hawkbit.im.authentication.SpPermission;
 import org.eclipse.hawkbit.repository.jpa.model.JpaDistributionSet;
 import org.eclipse.hawkbit.repository.jpa.model.JpaTarget;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
@@ -28,6 +29,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -140,6 +142,9 @@ public interface TargetRepository extends BaseEntityRepository<JpaTarget, Long>,
      */
     @Query(value = "SELECT DISTINCT t FROM JpaTarget t JOIN t.tags tt WHERE tt.id = :tag")
     Page<JpaTarget> findByTag(Pageable page, @Param("tag") Long tagId);
+
+    @Query(value = "SELECT COUNT(*) FROM sp_target t GROUP BY t.update_status ORDER BY t.update_status", nativeQuery = true)
+    List<Long> countByUpdateStatus();
 
     /**
      * Finds all {@link Target}s based on given {@link Target#getControllerId()}


### PR DESCRIPTION
As a first step to optimize `/info` endpoint, this PR replaces 5 inefficient queries for fetching target count by `update_status`,` such as:

`SELECT DISTINCT COUNT(DISTINCT(id)) FROM sp_target WHERE update_status = 0`

with a composite query that fetches target counts for multiple update statuses with a single query:

`SELECT COUNT(*) FROM sp_target GROUP BY update_status ORDER BY update_status`

The format of data exposed on the `/info` endpoint remains unchanged.