### PR TITLE
Fix searching for target attributes in Deployment dashboard

### DIFF
--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaTargetManagement.java
@@ -497,8 +497,7 @@ public class JpaTargetManagement implements TargetManagement {
         }
         if (!StringUtils.isEmpty(filterParams.getFilterBySearchText())) {
             if(isAttributeSearchEnabled()){
-                specList.add(TargetSpecifications
-                        .likeControllerIdOrName(filterParams.getFilterBySearchText()));
+                specList.add(TargetSpecifications.likeIdOrNameOrDescriptionOrAttributeValue(filterParams.getFilterBySearchText()));
             } else {
                 specList.add(TargetSpecifications.likeControllerIdOrName(filterParams.getFilterBySearchText()));
             }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/specifications/TargetSpecifications.java
@@ -282,6 +282,18 @@ public final class TargetSpecifications {
 
     /**
      * {@link Specification} for retrieving {@link Target}s by "like
+     * controllerId or like name or like description or like attribute value".
+     *
+     * @param searchText
+     *            to be filtered on
+     * @return the {@link Target} {@link Specification}
+     */
+    public static Specification<JpaTarget> likeIdOrNameOrDescriptionOrAttributeValue(final String searchText) {
+        return Specification.where(likeIdOrNameOrDescription(searchText)).or(likeAttributeValue(searchText));
+    }
+
+    /**
+     * {@link Specification} for retrieving {@link Target}s by "like
      * controllerId".
      *
      * @param distributionId


### PR DESCRIPTION
A function, which allowed searching across target attributes, was removed during the merge with upstream M8. This function has now been added back and activated so that searching across target attributes is now possible.