### PR TITLE
Fix/auto assignments for target type

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -398,7 +398,7 @@ public interface ControllerManagement {
      *
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    void triggerDistributionSetAssignmentCheck(String controllerId, @NotNull Map<String, String> attributes);
+    void triggerDistributionSetAssignmentCheck(String controllerId, @NotNull Map<String, String> attributes, String targetType);
 
     /**
      * Finds {@link Target} based on given controller ID returns found Target

--- a/hawkbit-repository/hawkbit-repository-jpa/pom.xml
+++ b/hawkbit-repository/hawkbit-repository-jpa/pom.xml
@@ -102,16 +102,6 @@
          <artifactId>allure-junit5</artifactId>
          <scope>test</scope>
       </dependency>
-      <dependency>
-         <groupId>junit</groupId>
-         <artifactId>junit</artifactId>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>junit</groupId>
-         <artifactId>junit</artifactId>
-         <scope>test</scope>
-      </dependency>
    </dependencies>
    
    <build>

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFieldExtractor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/TargetFieldExtractor.java
@@ -19,24 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.eclipse.hawkbit.repository.TargetFields.ASSIGNEDDS;
-import static org.eclipse.hawkbit.repository.TargetFields.ATTRIBUTE;
-import static org.eclipse.hawkbit.repository.TargetFields.CONTROLLERID;
-import static org.eclipse.hawkbit.repository.TargetFields.CREATEDAT;
-import static org.eclipse.hawkbit.repository.TargetFields.DESCRIPTION;
-import static org.eclipse.hawkbit.repository.TargetFields.ID;
-import static org.eclipse.hawkbit.repository.TargetFields.INSTALLEDDS;
-import static org.eclipse.hawkbit.repository.TargetFields.IPADDRESS;
-import static org.eclipse.hawkbit.repository.TargetFields.LASTCONTROLLERREQUESTAT;
-import static org.eclipse.hawkbit.repository.TargetFields.LASTMODIFIEDAT;
-import static org.eclipse.hawkbit.repository.TargetFields.METADATA;
-import static org.eclipse.hawkbit.repository.TargetFields.NAME;
-import static org.eclipse.hawkbit.repository.TargetFields.TAG;
-import static org.eclipse.hawkbit.repository.TargetFields.UPDATESTATUS;
+import static org.eclipse.hawkbit.repository.TargetFields.*;
 
 @Service
 public class TargetFieldExtractor {
-
     private String controllerId;
     private String name;
     private String description;
@@ -49,12 +35,13 @@ public class TargetFieldExtractor {
     private DistributionSet installedDs;
     private String createdAt;
     private String lastModifiedAt;
+    private String targetType;
 
     private final static String EMPTY_STRING = "";
 
     private TargetFieldData fieldData;
 
-    public TargetFieldData extractData(Target target, final Map<String, String> controllerAttributes){
+    public TargetFieldData extractData(Target target, final Map<String, String> controllerAttributes, final String targetType){
 
         fieldData = new TargetFieldData();
 
@@ -69,6 +56,7 @@ public class TargetFieldExtractor {
         fieldData.add(UPDATESTATUS, updateStatus);
         fieldData.add(IPADDRESS, address);
         fieldData.add(LASTCONTROLLERREQUESTAT, lastQuery);
+        fieldData.add(TARGETTYPE, NAME.getFieldName(), targetType);
 
         addMetadata();
         addAttributes(controllerAttributes);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/ControllerManagementTest.java
@@ -1619,16 +1619,19 @@ class ControllerManagementTest extends AbstractJpaIntegrationTest {
         DistributionSet set1 = testdataFactory.createDistributionSet("TestSet1");
         DistributionSet set2 = testdataFactory.createDistributionSet("TestSet2");
 
+        TargetType targetType = targetTypeManagement.create(entityFactory.targetType().create().description("").name("type").colour("#FFF"));
+
         targetManagement.create(entityFactory.target().create()
                 .controllerId("0123")
                 .name("Test target 0123")
-                .description("Description0123"));
-
+                .description("Description0123")
+                .targetType(targetType.getId()));
 
         targetManagement.create(entityFactory.target().create()
                 .controllerId("9999")
                 .name("Test target 9999")
-                .description("Description 9999"));
+                .description("Description 9999")
+                .targetType(targetType.getId()));
 
         TargetFilterQuery query1 = targetFilterQueryManagement.create(entityFactory.targetFilterQuery().create()
                 .autoAssignActionType(FORCED)
@@ -1642,8 +1645,8 @@ class ControllerManagementTest extends AbstractJpaIntegrationTest {
                 .name("Test query 2")
                 .query(TEST_QUERY_2));
 
-        controllerManagement.triggerDistributionSetAssignmentCheck("0123", targetManagement.getControllerAttributes("0123"));
-        controllerManagement.triggerDistributionSetAssignmentCheck("9999", targetManagement.getControllerAttributes("9999"));
+        controllerManagement.triggerDistributionSetAssignmentCheck("0123", targetManagement.getControllerAttributes("0123"), targetType.getName());
+        controllerManagement.triggerDistributionSetAssignmentCheck("9999", targetManagement.getControllerAttributes("9999"), targetType.getName());
 
         Target target1 = targetManagement.getByControllerID("0123").get();
         Target target2 = targetManagement.getByControllerID("9999").get();
@@ -1661,7 +1664,7 @@ class ControllerManagementTest extends AbstractJpaIntegrationTest {
         updatedAttributes.put("device_type", "dev_test_type");
 
         controllerManagement.updateControllerAttributes("0123", updatedAttributes, UpdateMode.REPLACE);
-        controllerManagement.triggerDistributionSetAssignmentCheck("0123", targetManagement.getControllerAttributes("0123"));
+        controllerManagement.triggerDistributionSetAssignmentCheck("0123", targetManagement.getControllerAttributes("0123"), targetType.getName());
 
         target1 = targetManagement.getByControllerID("0123").get();
 
@@ -1669,7 +1672,7 @@ class ControllerManagementTest extends AbstractJpaIntegrationTest {
         assertThat(target1.getAssignedDistributionSet().getName()).isEqualTo("TestSet2");
 
         controllerManagement.updateControllerAttributes("9999", updatedAttributes, UpdateMode.REPLACE);
-        controllerManagement.triggerDistributionSetAssignmentCheck("9999", targetManagement.getControllerAttributes("9999"));
+        controllerManagement.triggerDistributionSetAssignmentCheck("9999", targetManagement.getControllerAttributes("9999"), targetType.getName());
 
         target2 = targetManagement.getByControllerID("9999").get();
 

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFieldDataTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/TargetFieldDataTest.java
@@ -8,8 +8,9 @@
  */
 package org.eclipse.hawkbit.repository.jpa;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -30,8 +31,8 @@ import static org.eclipse.hawkbit.repository.TargetFields.TAG;
 import static org.eclipse.hawkbit.repository.TargetFields.UPDATESTATUS;
 import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.PENDING;
 import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.UNKNOWN;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TargetFieldDataTest {
 
@@ -49,7 +50,7 @@ public class TargetFieldDataTest {
     private TargetFieldData fieldData;
     private TargetFieldData fieldData2;
 
-    @Before
+    @BeforeEach
     public void setUp() throws InterruptedException {
 
         fieldData = new TargetFieldData();

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoactionstatuscleanup/AutoActionStatusCleanupSchedulerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoactionstatuscleanup/AutoActionStatusCleanupSchedulerTest.java
@@ -14,8 +14,9 @@ import io.qameta.allure.Story;
 import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;
 import org.eclipse.hawkbit.repository.jpa.autocleanup.AutoCleanupScheduler;
 import org.eclipse.hawkbit.repository.jpa.autocleanup.CleanupTask;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.support.locks.LockRegistry;
 
@@ -32,7 +33,7 @@ public class AutoActionStatusCleanupSchedulerTest extends AbstractJpaIntegration
     @Autowired
     private LockRegistry lockRegistry;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         counter.set(0);
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoactionstatuscleanup/AutoActionStatusCleanupTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autoactionstatuscleanup/AutoActionStatusCleanupTest.java
@@ -15,7 +15,7 @@ import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;
 import org.eclipse.hawkbit.repository.model.Action;
 import org.eclipse.hawkbit.repository.model.DistributionSet;
 import org.eclipse.hawkbit.repository.model.Target;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupSchedulerTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/autorolloutcleanup/AutoRolloutCleanupSchedulerTest.java
@@ -14,8 +14,9 @@ import io.qameta.allure.Story;
 import org.eclipse.hawkbit.repository.jpa.AbstractJpaIntegrationTest;
 import org.eclipse.hawkbit.repository.jpa.autocleanup.AutoCleanupScheduler;
 import org.eclipse.hawkbit.repository.jpa.autocleanup.CleanupTask;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.support.locks.LockRegistry;
 
@@ -33,7 +34,7 @@ public class AutoRolloutCleanupSchedulerTest extends AbstractJpaIntegrationTest 
     @Autowired
     private LockRegistry lockRegistry;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         counter.set(0);
     }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtilityTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RSQLUtilityTest.java
@@ -9,7 +9,7 @@
 package org.eclipse.hawkbit.repository.jpa.rsql;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlMatcherTest.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/test/java/org/eclipse/hawkbit/repository/jpa/rsql/RsqlMatcherTest.java
@@ -9,8 +9,9 @@
 package org.eclipse.hawkbit.repository.jpa.rsql;
 
 import org.eclipse.hawkbit.repository.jpa.TargetFieldData;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.GregorianCalendar;
@@ -33,8 +34,8 @@ import static org.eclipse.hawkbit.repository.TargetFields.UPDATESTATUS;
 import static org.eclipse.hawkbit.repository.jpa.rsql.RsqlMatcher.matches;
 import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.PENDING;
 import static org.eclipse.hawkbit.repository.model.TargetUpdateStatus.UNKNOWN;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class RsqlMatcherTest {
     final static String LOCALHOST = URI.create("http://127.0.0.1").toString();
@@ -242,7 +243,7 @@ public class RsqlMatcherTest {
     private TargetFieldData fieldData;
     private TargetFieldData fieldData2;
 
-    @Before
+    @BeforeEach
     public void setUp() {
 
         fieldData = new TargetFieldData();


### PR DESCRIPTION
- Extend `TargetFieldExtractor` to account for `target_type`.
- Modify existing tests to work with the modified functions in `TargetFieldExtractor` (and other functions used for auto assignment).
- Migrate tests in hawkbit-repository-jpa to use JUnit Jupiter to avoid dependency on JUnit 4