### PR TITLE
Sort targets within a rollout group by address

### DIFF
--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/RolloutCreate.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/builder/RolloutCreate.java
@@ -112,6 +112,15 @@ public interface RolloutCreate {
     RolloutCreate startAt(Long startAt);
 
     /**
+     * set isSortedByAddress
+     *
+     * @param isSortedByAddress
+     *            for {@link Rollout#getIsSortedByAddress()} ()}
+     * @return updated builder instance
+     */
+    RolloutCreate isSortedByAddress(boolean isSortedByAddress);
+
+    /**
      * @return peek on current state of {@link Rollout} in the builder
      */
     Rollout build();

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Rollout.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/model/Rollout.java
@@ -44,6 +44,8 @@ public interface Rollout extends NamedEntity {
 
     boolean getIsCleanedUp();
 
+    boolean getIsSortedByAddress();
+
     /**
      * @return {@link DistributionSet} that is rolled out
      */

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
@@ -122,6 +122,11 @@ public class TenantConfigurationProperties {
         public static final String ROLLOUT_APPROVAL_ENABLED = "rollout.approval.enabled";
 
         /**
+         * Represents setting if targets within a rollout group should be sorted by address
+         */
+        public static final String ROLLOUT_SORT_OPTION_ENALBED = "rollout.sort.enabled";
+
+        /**
          * Option setting for text search in target attributes
          */
         public static final String TARGET_SEARCH_ATTRIBUTES_ENABLED = "target.search.attributes.enabled";

--- a/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/builder/AbstractRolloutUpdateCreate.java
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/java/org/eclipse/hawkbit/repository/builder/AbstractRolloutUpdateCreate.java
@@ -34,6 +34,7 @@ public abstract class AbstractRolloutUpdateCreate<T> extends AbstractNamedEntity
     protected ActionType actionType;
     protected Long forcedTime;
     protected Long startAt;
+    protected boolean isSortedByAddress;
 
     @Min(Action.WEIGHT_MIN)
     @Max(Action.WEIGHT_MAX)
@@ -111,6 +112,18 @@ public abstract class AbstractRolloutUpdateCreate<T> extends AbstractNamedEntity
         return (T) this;
     }
 
+    /**
+     * Set start of the Rollout
+     *
+     * @param isSortedByAddress
+     *            start time point
+     * @return this builder
+     */
+    public T isSortedByAddress(final boolean isSortedByAddress) {
+        this.isSortedByAddress = isSortedByAddress;
+        return (T) this;
+    }
+
     public Optional<Long> getSet() {
         return Optional.ofNullable(set);
     }
@@ -129,5 +142,9 @@ public abstract class AbstractRolloutUpdateCreate<T> extends AbstractNamedEntity
 
     public Optional<Long> getStartAt() {
         return Optional.ofNullable(startAt);
+    }
+
+    public boolean getIsSortedByAddress() {
+        return isSortedByAddress;
     }
 }

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutExecutor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutExecutor.java
@@ -585,7 +585,9 @@ public class JpaRolloutExecutor implements RolloutExecutor {
                 targetList = targetList.stream().sorted(addressStringComparator).collect(Collectors.toList());
             }
 
-            LOGGER.info("Assigning {} targets to rollout with Id {}", targets.getNumberOfElements(), rollout.getId());
+            LOGGER.debug("Assigning {} targets to rollout with Id {}", targets.getNumberOfElements(), rollout.getId());
+            LOGGER.debug("Targets in the rollout group are \n{}", targetList.stream().map(target -> target.getId() + ":" + target.getAddress()).collect(Collectors.joining(", ", "{", "}")));
+
             createAssignmentOfTargetsToGroup(targetList, group);
             return Long.valueOf(targets.getNumberOfElements());
         });

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutExecutor.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutExecutor.java
@@ -574,7 +574,7 @@ public class JpaRolloutExecutor implements RolloutExecutor {
             final PageRequest pageRequest = PageRequest.of(0, Math.toIntExact(limit));
             final List<Long> readyGroups = RolloutHelper.getGroupsByStatusIncludingGroup(rollout.getRolloutGroups(),
                     RolloutGroupStatus.READY, group);
-            final boolean useAddressForSorting = true;
+            final boolean useAddressForSorting = rollout.getIsSortedByAddress();
 
             final Comparator<Target> addressStringComparator = Comparator.comparing(o -> o.getAddress().toString());
             final Slice<Target> targets = targetManagement.findByTargetFilterQueryAndNotInRolloutGroupsAndCompatible(

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaRolloutManagement.java
@@ -536,6 +536,8 @@ public class JpaRolloutManagement implements RolloutManagement {
         update.getActionType().ifPresent(rollout::setActionType);
         update.getForcedTime().ifPresent(rollout::setForcedTime);
         update.getWeight().ifPresent(rollout::setWeight);
+        rollout.setIsSortedByAddress(update.getIsSortedByAddress());
+
         // reseting back to manual start is done by setting start at time to
         // null
         rollout.setStartAt(update.getStartAt().orElse(null));

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/builder/JpaRolloutCreate.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/builder/JpaRolloutCreate.java
@@ -30,6 +30,7 @@ public class JpaRolloutCreate extends AbstractRolloutUpdateCreate<RolloutCreate>
         rollout.setTargetFilterQuery(targetFilterQuery);
         rollout.setStartAt(startAt);
         rollout.setWeight(weight);
+        rollout.setIsSortedByAddress(isSortedByAddress);
 
         if (actionType != null) {
             rollout.setActionType(actionType);

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/model/JpaRollout.java
@@ -143,6 +143,9 @@ public class JpaRollout extends AbstractJpaNamedEntity implements Rollout, Event
     @Column(name = "is_cleaned_up", nullable = false)
     private boolean isCleanedUp = false;
 
+    @Column(name = "is_sorted_by_address", nullable = false)
+    private boolean isSortedByAddress = false;
+
     @Transient
     private transient TotalTargetCountStatus totalTargetCountStatus;
 
@@ -228,6 +231,10 @@ public class JpaRollout extends AbstractJpaNamedEntity implements Rollout, Event
     public boolean getIsCleanedUp() { return isCleanedUp; }
 
     public void setIsCleanedUp(final boolean isCleanedUp) { this.isCleanedUp = isCleanedUp; }
+
+    public boolean getIsSortedByAddress() { return isSortedByAddress; }
+
+    public void setIsSortedByAddress(final boolean isSortedByAddress) { this.isSortedByAddress = isSortedByAddress; }
 
     @Override
     public long getTotalTargets() {

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_29__add_column_is_sorted_by_address__DB2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/DB2/V1_12_29__add_column_is_sorted_by_address__DB2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_sorted_by_address BOOLEAN DEFAULT '0' NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_29__add_column_is_sorted_by_address__H2.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/H2/V1_12_29__add_column_is_sorted_by_address__H2.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_sorted_by_address BOOLEAN DEFAULT '0' NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_29__add_column_is_sorted_by_address__MYSQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/MYSQL/V1_12_29__add_column_is_sorted_by_address__MYSQL.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_sorted_by_address BOOLEAN DEFAULT '0' NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_29__add_column_is_sorted_by_address__POSTGRESQL.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/POSTGRESQL/V1_12_29__add_column_is_sorted_by_address__POSTGRESQL.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_sorted_by_address BOOLEAN DEFAULT '0' NOT NULL;

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_29__add_column_is_sorted_by_address__SQL_SERVER.sql
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/resources/db/migration/SQL_SERVER/V1_12_29__add_column_is_sorted_by_address__SQL_SERVER.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sp_rollout
+    ADD COLUMN is_sorted_by_address BOOLEAN DEFAULT '0' NOT NULL;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/data/mappers/RolloutToProxyRolloutMapper.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/data/mappers/RolloutToProxyRolloutMapper.java
@@ -38,6 +38,7 @@ public class RolloutToProxyRolloutMapper extends AbstractNamedEntityToProxyNamed
         proxyRollout.setActionType(rollout.getActionType());
         proxyRollout.setTargetFilterQuery(rollout.getTargetFilterQuery());
         proxyRollout.setStartAt(rollout.getStartAt());
+        proxyRollout.setIsSortedByAddress(rollout.getIsSortedByAddress());
 
         return proxyRollout;
     }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/data/proxies/ProxyRollout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/data/proxies/ProxyRollout.java
@@ -44,6 +44,8 @@ public class ProxyRollout extends ProxyNamedEntity {
 
     private ActionType actionType;
 
+    private boolean isSortedByAddress;
+
     /**
      * Constructor
      */
@@ -241,6 +243,25 @@ public class ProxyRollout extends ProxyNamedEntity {
      */
     public void setStartAt(final Long startAt) {
         this.startAt = startAt;
+    }
+
+    /**
+     * Gets the boolean isSortedByAddress
+     *
+     * @return isSortedByAddress
+     */
+    public boolean getIsSortedByAddress() {
+        return isSortedByAddress;
+    }
+
+    /**
+     * Sets the boolean isSortedByAddress
+     *
+     * @param isSortedByAddress
+     *            A boolean that indicates if targets within a rollout group should be sorted by IP address
+     */
+    public void setIsSortedByAddress(final boolean isSortedByAddress) {
+        this.isSortedByAddress = isSortedByAddress;
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/data/proxies/ProxyRolloutForm.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/data/proxies/ProxyRolloutForm.java
@@ -35,6 +35,7 @@ public class ProxyRolloutForm implements Serializable, NameAware, DsIdAware, Tar
     private Long forcedTime;
     private AutoStartOption autoStartOption;
     private Long startAt;
+    private boolean isSortedByAddress;
 
     /**
      * Gets the rollout form id
@@ -146,4 +147,8 @@ public class ProxyRolloutForm implements Serializable, NameAware, DsIdAware, Tar
     public void setStartAt(final Long startAt) {
         this.startAt = startAt;
     }
+    public boolean getIsSortedByAddress() {
+        return isSortedByAddress;
+    }
+    public void setIsSortedByAddress(final boolean sortedByAddress) { this.isSortedByAddress = sortedByAddress; }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/data/proxies/ProxyRolloutWindow.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/common/data/proxies/ProxyRolloutWindow.java
@@ -55,6 +55,7 @@ public class ProxyRolloutWindow implements Serializable {
         setTargetFilterQuery(rollout.getTargetFilterQuery());
         setDistributionSetInfo(rollout.getDsInfo());
         setNumberOfGroups(rollout.getNumberOfGroups());
+        setIsSortedByAddress(rollout.getIsSortedByAddress());
     }
 
     /**
@@ -469,5 +470,24 @@ public class ProxyRolloutWindow implements Serializable {
      */
     public enum GroupDefinitionMode {
         SIMPLE, ADVANCED;
+    }
+
+    /**
+     * Sets the form isSortedByAddress
+     *
+     * @param isSortedByAddress
+     *            rollout form isSortedByAddress
+     */
+    public void setIsSortedByAddress(final boolean isSortedByAddress) {
+        rolloutForm.setIsSortedByAddress(isSortedByAddress);
+    }
+
+    /**
+     * Gets the rollout form isSortedByAddress
+     *
+     * @return form isSortedByAddress
+     */
+    public boolean getIsSortedByAddress() {
+        return rolloutForm.getIsSortedByAddress();
     }
 }

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/components/RolloutFormLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/components/RolloutFormLayout.java
@@ -11,7 +11,7 @@ package org.eclipse.hawkbit.ui.rollout.window.components;
 import java.util.function.Consumer;
 
 import com.vaadin.server.Sizeable;
-import org.eclipse.hawkbit.repository.jpa.autorolloutcleanup.AutoRolloutCleanupScheduler;
+import com.vaadin.ui.*;
 import org.eclipse.hawkbit.repository.model.Action.ActionType;
 import org.eclipse.hawkbit.repository.model.TargetFilterQuery;
 import org.eclipse.hawkbit.ui.common.builder.BoundComponent;
@@ -19,9 +19,7 @@ import org.eclipse.hawkbit.ui.common.builder.FormComponentBuilder;
 import org.eclipse.hawkbit.ui.common.builder.TextAreaBuilder;
 import org.eclipse.hawkbit.ui.common.data.providers.DistributionSetStatelessDataProvider;
 import org.eclipse.hawkbit.ui.common.data.providers.TargetFilterQueryDataProvider;
-import org.eclipse.hawkbit.ui.common.data.proxies.ProxyDistributionSet;
-import org.eclipse.hawkbit.ui.common.data.proxies.ProxyRolloutForm;
-import org.eclipse.hawkbit.ui.common.data.proxies.ProxyTargetFilterQuery;
+import org.eclipse.hawkbit.ui.common.data.proxies.*;
 import org.eclipse.hawkbit.ui.components.SPUIComponentProvider;
 import org.eclipse.hawkbit.ui.management.miscs.ActionTypeOptionGroupAssignmentLayout;
 import org.eclipse.hawkbit.ui.rollout.window.components.AutoStartOptionGroupLayout.AutoStartOption;
@@ -34,17 +32,11 @@ import com.vaadin.data.HasValue;
 import com.vaadin.data.ValidationException;
 import com.vaadin.data.Validator;
 import com.vaadin.data.validator.LongRangeValidator;
-import com.vaadin.ui.ComboBox;
-import com.vaadin.ui.Component;
-import com.vaadin.ui.GridLayout;
-import com.vaadin.ui.TextArea;
-import com.vaadin.ui.TextField;
 
 /**
  * Rollout form layout
  */
 public class RolloutFormLayout extends ValidatableLayout {
-
     private static final String PROMPT_TARGET_FILTER = "prompt.target.filter";
     private static final String MESSAGE_ROLLOUT_FILTER_TARGET_EXISTS = "message.rollout.filter.target.exists";
     private static final String TEXTFIELD_DESCRIPTION = "textfield.description";
@@ -52,6 +44,7 @@ public class RolloutFormLayout extends ValidatableLayout {
     private static final String TEXTFIELD_NAME = "textfield.name";
     private static final String CAPTION_ROLLOUT_START_TYPE = "caption.rollout.start.type";
     private static final String CAPTION_ROLLOUT_ACTION_TYPE = "caption.rollout.action.type";
+    private static final String CAPTION_ROLLOUT_SORT_OPTION = "caption.rollout.sort_option";
 
     private static final int CAPTION_COLUMN = 0;
     private static final int FIELD_COLUMN = 1;
@@ -72,6 +65,7 @@ public class RolloutFormLayout extends ValidatableLayout {
     private final TextArea descriptionField;
     private final BoundComponent<ActionTypeOptionGroupAssignmentLayout> actionTypeLayout;
     private final BoundComponent<AutoStartOptionGroupLayout> autoStartOptionGroupLayout;
+    private final CheckBox sortOptionsCheckBox;
 
     private Long rolloutId;
     private Long totalTargets;
@@ -107,9 +101,19 @@ public class RolloutFormLayout extends ValidatableLayout {
         this.descriptionField = createDescription();
         this.actionTypeLayout = createActionTypeOptionGroupLayout();
         this.autoStartOptionGroupLayout = createAutoStartOptionGroupLayout();
+        this.sortOptionsCheckBox = createSortOptionsCheckBox();
 
         addValueChangeListeners();
         setValidationStatusByBinder(binder);
+    }
+
+    /**
+     * Create checkbox for sorting targets in rollout group
+     *
+     * @return input component
+     */
+    private CheckBox createSortOptionsCheckBox() {
+        return FormComponentBuilder.createCheckBox(UIComponentIdProvider.ROLLOUT_SORT_ENABLED_CHECKBOX, binder, ProxyRolloutForm::getIsSortedByAddress, ProxyRolloutForm::setIsSortedByAddress);
     }
 
     /**
@@ -267,11 +271,15 @@ public class RolloutFormLayout extends ValidatableLayout {
         layout.addComponent(descriptionField, FIELD_COLUMN, 3);
 
         final int lastColumn = layout.getColumns() - 1;
+
         layout.addComponent(SPUIComponentProvider.generateLabel(i18n, CAPTION_ROLLOUT_ACTION_TYPE), CAPTION_COLUMN, 4);
         layout.addComponent(actionTypeLayout.getComponent(), FIELD_COLUMN, 4, lastColumn, 4);
 
         layout.addComponent(SPUIComponentProvider.generateLabel(i18n, CAPTION_ROLLOUT_START_TYPE), CAPTION_COLUMN, 5);
         layout.addComponent(autoStartOptionGroupLayout.getComponent(), FIELD_COLUMN, 5, lastColumn, 5);
+
+        layout.addComponent(SPUIComponentProvider.generateLabel(i18n, CAPTION_ROLLOUT_SORT_OPTION), CAPTION_COLUMN, 6);
+        layout.addComponent(sortOptionsCheckBox, FIELD_COLUMN, 6, lastColumn, 6);
     }
 
     /**

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/controllers/AddRolloutWindowController.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/controllers/AddRolloutWindowController.java
@@ -109,7 +109,8 @@ public class AddRolloutWindowController
                 .targetFilterQuery(entity.getTargetFilterQuery()).actionType(entity.getActionType())
                 .forcedTime(entity.getActionType() == ActionType.TIMEFORCED ? entity.getForcedTime()
                         : RepositoryModelConstants.NO_FORCE_TIME)
-                .startAt(entity.getStartAtByOption());
+                .startAt(entity.getStartAtByOption())
+                .isSortedByAddress(entity.getIsSortedByAddress());
 
         final Rollout rolloutToCreate;
         if (GroupDefinitionMode.SIMPLE == entity.getGroupDefinitionMode()) {

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/layouts/AddRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/layouts/AddRolloutWindowLayout.java
@@ -79,7 +79,7 @@ public class AddRolloutWindowLayout extends AbstractRolloutWindowLayout {
 
     @Override
     protected void addComponents(final GridLayout rootLayout) {
-        rootLayout.setRows(7);
+        rootLayout.setRows(8);
 
         final int lastRowIdx = rootLayout.getRows() - 1;
         final int lastColumnIdx = rootLayout.getColumns() - 1;

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/layouts/UpdateRolloutWindowLayout.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/rollout/window/layouts/UpdateRolloutWindowLayout.java
@@ -42,7 +42,7 @@ public class UpdateRolloutWindowLayout extends AbstractRolloutWindowLayout {
 
     @Override
     protected void addComponents(final GridLayout rootLayout) {
-        rootLayout.setRows(6);
+        rootLayout.setRows(7);
 
         final int lastColumnIdx = rootLayout.getColumns() - 1;
 

--- a/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UIComponentIdProvider.java
+++ b/hawkbit-ui/src/main/java/org/eclipse/hawkbit/ui/utils/UIComponentIdProvider.java
@@ -1576,6 +1576,12 @@ public final class UIComponentIdProvider {
 
     /**
      * Configuration checkbox for
+     * {@link TenantConfigurationKey#ROLLOUT_SORT_OPTION_ENALBED}
+     */
+    public static final String ROLLOUT_SORT_ENABLED_CHECKBOX = "rollout.sort.enabled.checkbox";
+
+    /**
+     * Configuration checkbox for
      * {@link TenantConfigurationKey#TARGET_SEARCH_ATTRIBUTES_ENABLED}
      */
     public static final String TARGET_SEARCH_ATTRIBUTES = "target.search.attributes.checkbox";

--- a/hawkbit-ui/src/main/resources/messages.properties
+++ b/hawkbit-ui/src/main/resources/messages.properties
@@ -843,6 +843,7 @@ caption.rollout.action.type = Action type
 message.rollout.remaining.targets.error = Not all targets are addressed
 textfield.rollout.copied.name = Copy of {0}
 label.rollout.targets.in.group = {0} in {1}
+caption.rollout.sort_option = Sort targets within group by address
 caption.rollout.start.type = Start type
 caption.rollout.start.manual = Manual
 caption.rollout.start.manual.desc = The user starts the rollout manually.


### PR DESCRIPTION
Underlying idea is to improve the chances that targets in the same network receive firmware updates withou delays among them. 

- Include a column `is_sorted_by_address` (default value of `false` or `0`) to `sp_rollout` table.
- Add a checkbox to sort targets by address to the rollout creation window:
<img src="https://github.com/devolo/hawkbit/assets/83754781/d2c4f230-d63d-4205-8256-aa9228b44541" width="60%">  

- Link the checkbox value to column via JPA and ProxyMapper service.
- Add logs for debugging.
