### PR TITLE
Check for device tag and set poll interval accordingly

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/ControllerPollProperties.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/ControllerPollProperties.java
@@ -51,6 +51,12 @@ public class ControllerPollProperties implements Serializable {
     private String pollingOverdueTime = "00:05:00";
 
     /**
+     * Controller polling time for targets marked for low poll that can be configured systemwide and by tenant
+     * in HH:MM:SS notation.
+     */
+    private String pollingTimeForLowPollTargets = "00:00:10";
+
+    /**
      * This configuration value is used to change the polling interval so that
      * controller tries to poll at least these many times between the last
      * polling and before start of maintenance window. The polling interval is
@@ -74,6 +80,14 @@ public class ControllerPollProperties implements Serializable {
 
     public void setPollingOverdueTime(final String pollingOverdueTime) {
         this.pollingOverdueTime = pollingOverdueTime;
+    }
+
+    public String getPollingTimeForLowPollTargets() {
+        return pollingTimeForLowPollTargets;
+    }
+
+    public void setPollingTimeForLowPollTargets(final String pollingTimeForLowPollTargets) {
+        this.pollingTimeForLowPollTargets = pollingTimeForLowPollTargets;
     }
 
     public String getMaxPollingTime() {

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/repository/ControllerManagement.java
@@ -266,6 +266,15 @@ public interface ControllerManagement {
     String getPollingTime();
 
     /**
+     * Returns configured polling interval for low poll targets at which the controller polls hawkBit
+     * server.
+     *
+     * @return current {@link TenantConfigurationKey#POLLING_TIME_INTERVAL}.
+     */
+    @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
+    String getPollingTimeForLowPollTargets();
+
+    /**
      * Returns the configured minimum polling interval.
      *
      * @return current {@link TenantConfigurationKey#MIN_POLLING_TIME_INTERVAL}.
@@ -275,7 +284,7 @@ public interface ControllerManagement {
 
     /**
      * Returns the count to be used for reducing polling interval while calling
-     * {@link ControllerManagement#getPollingTimeForAction(long)}.
+     * {@link ControllerManagement#getPollingTimeForAction(long, String)}.
      *
      * @return configured value of
      *         {@link TenantConfigurationKey#MAINTENANCE_WINDOW_POLL_COUNT}.
@@ -300,7 +309,7 @@ public interface ControllerManagement {
      * @return current {@link TenantConfigurationKey#POLLING_TIME_INTERVAL}.
      */
     @PreAuthorize(SpringEvalExpressions.IS_CONTROLLER)
-    String getPollingTimeForAction(long actionId);
+    String getPollingTimeForAction(long actionId, String pollingTime);
 
     /**
      * Checks if a given target has currently or has even been assigned to the

--- a/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
+++ b/hawkbit-repository/hawkbit-repository-api/src/main/java/org/eclipse/hawkbit/tenancy/configuration/TenantConfigurationProperties.java
@@ -96,6 +96,12 @@ public class TenantConfigurationProperties {
 
         /**
          * See system default in
+         * {@link ControllerPollProperties#getPollingTimeForLowPollTargets()}.
+         */
+        public static final String POLLING_TIME_INTERVAL_FOR_LOW_POLL_TARGETS = "pollingTimeForLowPollTargets";
+
+        /**
+         * See system default in
          * {@link ControllerPollProperties#getMinPollingTime()}.
          */
         public static final String MIN_POLLING_TIME_INTERVAL = "minPollingTime";

--- a/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
@@ -13,6 +13,7 @@ hawkbit.controller.pollingTime=00:05:00
 hawkbit.controller.pollingOverdueTime=00:05:00
 hawkbit.controller.maxPollingTime=23:59:59
 hawkbit.controller.minPollingTime=00:00:30
+hawkbit.controller.pollingTimeForLowPollTargets=00:00:10
 
 # This configuration value is used to change the polling interval so that
 # controller tries to poll at least these many times between the last polling
@@ -54,6 +55,10 @@ hawkbit.server.tenant.configuration.authentication-gatewaytoken-key.defaultValue
 hawkbit.server.tenant.configuration.polling-time.keyName=pollingTime
 hawkbit.server.tenant.configuration.polling-time.defaultValue=${hawkbit.controller.pollingTime}
 hawkbit.server.tenant.configuration.polling-time.validator=org.eclipse.hawkbit.tenancy.configuration.validator.TenantConfigurationPollingDurationValidator
+
+hawkbit.server.tenant.configuration.polling-time-for-low-poll-targets.keyName=pollingTimeForLowPollTargets
+hawkbit.server.tenant.configuration.polling-time-for-low-poll-targets.defaultValue=${hawkbit.controller.pollingTimeForLowPollTargets}
+hawkbit.server.tenant.configuration.polling-time-for-low-poll-targets.validator=org.eclipse.hawkbit.tenancy.configuration.validator.TenantConfigurationPollingDurationValidator
 
 hawkbit.server.tenant.configuration.min-polling-time.keyName=minPollingTime
 hawkbit.server.tenant.configuration.min-polling-time.defaultValue=${hawkbit.controller.minPollingTime}

--- a/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
+++ b/hawkbit-repository/hawkbit-repository-jpa/src/main/java/org/eclipse/hawkbit/repository/jpa/JpaControllerManagement.java
@@ -175,6 +175,12 @@ public class JpaControllerManagement extends JpaActionManagement implements Cont
                 .getConfigurationValue(TenantConfigurationKey.POLLING_TIME_INTERVAL, String.class).getValue());
     }
 
+    @Override
+    public String getPollingTimeForLowPollTargets() {
+        return systemSecurityContext.runAsSystem(() -> tenantConfigurationManagement
+                .getConfigurationValue(TenantConfigurationKey.POLLING_TIME_INTERVAL_FOR_LOW_POLL_TARGETS, String.class).getValue());
+    }
+
     /**
      * Returns the configured minimum polling interval.
      *
@@ -188,7 +194,7 @@ public class JpaControllerManagement extends JpaActionManagement implements Cont
 
     /**
      * Returns the count to be used for reducing polling interval while calling
-     * {@link ControllerManagement#getPollingTimeForAction(long)}.
+     * {@link ControllerManagement#getPollingTimeForAction(long, String)}.
      *
      * @return configured value of
      *         {@link TenantConfigurationKey#MAINTENANCE_WINDOW_POLL_COUNT}.
@@ -200,15 +206,15 @@ public class JpaControllerManagement extends JpaActionManagement implements Cont
     }
 
     @Override
-    public String getPollingTimeForAction(final long actionId) {
+    public String getPollingTimeForAction(final long actionId, final String pollingTime) {
 
         final JpaAction action = getActionAndThrowExceptionIfNotFound(actionId);
 
         if (!action.hasMaintenanceSchedule() || action.isMaintenanceScheduleLapsed()) {
-            return getPollingTime();
+            return pollingTime;
         }
 
-        return new EventTimer(getPollingTime(), getMinPollingTime(), ChronoUnit.SECONDS)
+        return new EventTimer(pollingTime, getMinPollingTime(), ChronoUnit.SECONDS)
                 .timeToNextEvent(getMaintenanceWindowPollCount(), action.getMaintenanceWindowStartTime().orElse(null));
     }
 


### PR DESCRIPTION
Targets normally have a poll interval of six hours on devolo's hawkBit servers. 

For certain targets that we want to monitor in a more fine-grained manner, e.g., customer reported an issue and we want to see if the fix works, we want to temporarily set the poll interval to a lower value (i.e., device polls more frequently).

This PR makes this possible by setting a different poll interval for targets with the tag containing "low-poll". The poll interval will revert to default once this tag is removed in the hawkBit UI. 

The poll interval for such low-poll targets is configured to a default of 10 minutes and can be configured in the `application.properties` file, e.g. to set it to 15 minutes:

`hawkbit.controller.pollingTimeForLowPollTargets=00:00:15`