### PR TITLE
Fix poll interval for targets with low-poll tag

### DIFF
--- a/hawkbit-core/src/main/java/org/eclipse/hawkbit/ControllerPollProperties.java
+++ b/hawkbit-core/src/main/java/org/eclipse/hawkbit/ControllerPollProperties.java
@@ -54,7 +54,7 @@ public class ControllerPollProperties implements Serializable {
      * Controller polling time for targets marked for low poll that can be configured systemwide and by tenant
      * in HH:MM:SS notation.
      */
-    private String pollingTimeForLowPollTargets = "00:00:10";
+    private String pollingTimeForLowPollTargets = "00:10:00";
 
     /**
      * This configuration value is used to change the polling interval so that

--- a/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
+++ b/hawkbit-repository/hawkbit-repository-core/src/main/resources/hawkbit-repository-defaults.properties
@@ -13,7 +13,7 @@ hawkbit.controller.pollingTime=00:05:00
 hawkbit.controller.pollingOverdueTime=00:05:00
 hawkbit.controller.maxPollingTime=23:59:59
 hawkbit.controller.minPollingTime=00:00:30
-hawkbit.controller.pollingTimeForLowPollTargets=00:00:10
+hawkbit.controller.pollingTimeForLowPollTargets=00:10:00
 
 # This configuration value is used to change the polling interval so that
 # controller tries to poll at least these many times between the last polling


### PR DESCRIPTION
Poll interval was incorrectly set to 10 seconds; has been changed to 10 minutes with this PR.